### PR TITLE
Load seq for using its function

### DIFF
--- a/cascading-dir-locals.el
+++ b/cascading-dir-locals.el
@@ -42,6 +42,7 @@
 ;;; Code:
 
 (eval-when-compile (require 'subr-x))
+(require 'seq)
 
 (defcustom cascading-dir-locals-debug nil
   "When non-nil, print debug messages regarding the lookup and collection of dir-locals files."


### PR DESCRIPTION
This fixes a following byte-compile warning.

```
cascading-dir-locals.el:99:1:Warning: the function ‘seq-map’ is not known to
    be defined.
```