### PR TITLE
Add instructions for installing via GNU Guix

### DIFF
--- a/README.org
+++ b/README.org
@@ -32,6 +32,12 @@ If you use both MELPA and =use-package=, you can use this, too:
   (cascading-dir-locals-mode 1))
 #+end_src
 
+** GNU Guix
+
+If you use [[https://guix.gnu.org/][GNU Guix]], this package can be installed via =guix install
+emacs-cascading-dir-locals=.  Once installed, edit your Emacs configuration as
+above to enable the package.
+
 * Example
 
 Consider this example directory tree:


### PR DESCRIPTION
A recipe for this package was added to Guix on 2021-05-26: https://git.savannah.gnu.org/cgit/guix.git/commit/?id=147b86ad30bb574e0d3b4e30486b70ae31fd16c3


----

#